### PR TITLE
Show two versions: `telegram-lambdabot` and `lambdabot-core`

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -72,7 +72,7 @@ main = do
   dir <- P.getDataDir
   exitWith <=< lambdabotMain modulesInfo $
     [ dataDir ==> dir
-    , lbVersion ==> P.version
+    , telegramLambdabotVersion ==> P.version
     , onStartupCmds ==> ["telegram"]
     , enableInsults ==> False
     ] ++ config'

--- a/src/Lambdabot/Config/Telegram.hs
+++ b/src/Lambdabot/Config/Telegram.hs
@@ -4,6 +4,8 @@
 {-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
 module Lambdabot.Config.Telegram where
 
+import Data.Version
 import Lambdabot.Config
 
-config "telegramBotName"          [t| String                  |] [| "TelegramLambdabot"         |]
+config "telegramBotName"           [t| String                  |] [| "TelegramLambdabot"         |]
+config "telegramLambdabotVersion"  [t| Version                 |] [| Version [] [] |]

--- a/src/Lambdabot/Plugin/Telegram.hs
+++ b/src/Lambdabot/Plugin/Telegram.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE StrictData #-}
 module Lambdabot.Plugin.Telegram where
 
@@ -13,6 +14,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Version
 import System.Timeout.Lifted
 import Telegram.Bot.Simple
 
@@ -31,6 +33,9 @@ import Lambdabot.Plugin.Telegram.Message
 import Lambdabot.Plugin.Telegram.Shared
 
 -- * Lambdabot state
+
+lambdabotVersion :: String
+lambdabotVersion = VERSION_lambdabot_core
 
 telegramPlugins :: [String]
 telegramPlugins = ["telegram"]
@@ -64,6 +69,20 @@ telegramPlugin = newModule
             _ <- fork (telegramLoop histFile `finally` unlockRC)
             ldebug "telegram loop started"
             return ()
+        }
+    , (command "tgversion")
+        { help = say $
+            "version/source. Report version(s) and git repo of this bot."
+        , process = const $ do
+            ver <- getConfig telegramLambdabotVersion
+            say $ unlines $
+              [ "telegram-lambdabot v."
+                <> showVersion ver
+                <> ". git clone https://github.com/swamp-agr/lambdabot-telegram-plugins.git"
+              , "lambdabot-core v."
+                <> lambdabotVersion
+                <> ". git clone https://github.com/lambdabot/lambdabot.git"
+              ]
         }
     ]
   }

--- a/src/Lambdabot/Plugin/Telegram/Bot.hs
+++ b/src/Lambdabot/Plugin/Telegram/Bot.hs
@@ -93,7 +93,7 @@ data UndoCmd = Undo Msg | Do Msg
 data UnmtlCmd = Unmtl Msg
   deriving (Generic, FromCommand)
 
-data VersionCmd = Version Msg
+data VersionCmd = Tgversion Msg
   deriving (Generic, FromCommand)
 
 data HelpCmd = Help Msg
@@ -196,7 +196,7 @@ updateToAction TelegramState{..} update
   = SendModule <$> (UnmtlModule <$> (Unmtl <$> updateToMsg update))
   -- version
   | isCommand "version" update
-  = SendModule <$> (VersionModule <$> (Version <$> updateToMsg update))
+  = SendModule <$> (VersionModule <$> (Tgversion <$> updateToMsg update))
   -- help
   | isCommand "help" update
   = SendModule <$> (HelpModule <$> (Help <$> updateToMsg update))


### PR DESCRIPTION
- Introduce `tgversion` command in `telegram` plugin.
- Map `/version` to `tgversion` instead of `version` command from `version` plugin.
- Respond with both lambdabot and telegram package versions.