### PR TITLE
Exclusive sandbox for chats, remove shared state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist-newstyle
 log
 *.pid
 .ghc*
+State/L*.hs

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,6 @@ import Control.Monad.Identity
 import Data.Char
 import Data.Version
 import Lambdabot.Main
-import Lambdabot.Plugin.Haskell
 import System.Console.GetOpt
 import System.Environment
 import System.Exit
@@ -37,7 +36,7 @@ flags =
       (lv, []):_ -> return lv
       _          -> usage
         [ "Unknown log level."
-        , "Valid levels are: " ++ show [DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY]
+        , "Valid levels are: " ++ show [minBound .. maxBound :: Priority]
         ]
         
 versionString :: String

--- a/app/Modules.hs
+++ b/app/Modules.hs
@@ -10,4 +10,4 @@ import Lambdabot.Plugin.Haskell
 import Lambdabot.Plugin.Telegram
 
 modulesInfo :: Modules
-modulesInfo = $(modules $ corePlugins ++ haskellPlugins ++ telegramPlugins)
+modulesInfo = $(modules $ corePlugins ++ customHaskellPlugins ++ telegramPlugins)

--- a/lambdabot-telegram-plugins.cabal
+++ b/lambdabot-telegram-plugins.cabal
@@ -36,13 +36,16 @@ library
                     , containers
                     , dependent-map
                     , dependent-sum
+                    , directory
                     , edit-distance
+                    , haskell-src-exts-simple
                     , telegram-bot-simple >= 0.4.3
                     , text
                     , lambdabot-core
                     , lifted-base
                     , monad-control
                     , mtl
+                    , process
                     , regex-tdfa
                     , split
                     , stm

--- a/src/Lambdabot/Config/Telegram.hs
+++ b/src/Lambdabot/Config/Telegram.hs
@@ -9,3 +9,31 @@ import Lambdabot.Config
 
 config "telegramBotName"           [t| String                  |] [| "TelegramLambdabot"         |]
 config "telegramLambdabotVersion"  [t| Version                 |] [| Version [] [] |]
+config "muevalBinary"       [t| String                  |] [| "mueval"      |]
+
+
+-- extensions to enable for the interpreted expression
+-- (and probably also L.hs if it doesn't already have these set)
+defaultExts :: [String]
+defaultExts =
+    [ "ImplicitPrelude" -- workaround for bug in hint package
+    , "ExtendedDefaultRules"
+    ]
+
+configWithMerge [| (++) |] "languageExts"   [t| [String] |] [| defaultExts |]
+
+trustedPkgs :: [String]
+trustedPkgs =
+    [ "array"
+    , "base"
+    , "bytestring"
+    , "containers"
+    , "lambdabot-trusted"
+    , "random"
+    ]
+
+configWithMerge [| (++) |] "trustedPackages"    [t| [String] |] [| trustedPkgs   |]
+
+config "evalPrefixes"       [t| [String]                |] [| [">"]         |]
+config "ghcBinary"          [t| String                  |] [| "ghc"         |]
+config "ghciBinary"         [t| String                  |] [| "ghci"        |]

--- a/src/Lambdabot/Plugin/Telegram.hs
+++ b/src/Lambdabot/Plugin/Telegram.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE StrictData #-}
 module Lambdabot.Plugin.Telegram where
@@ -6,15 +7,21 @@ module Lambdabot.Plugin.Telegram where
 import Codec.Binary.UTF8.String
 import Control.Concurrent.Lifted
 import Control.Concurrent.STM
-import Control.Exception.Lifted (finally)
+import Control.Exception.Lifted (SomeException, try, finally)
 import Control.Monad (void, when)
 import Control.Monad.State (gets, lift, liftIO, modify)
 import Data.Char
+import Data.List
 import qualified Data.Map.Strict as Map
+import Data.Ord
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Version
+import qualified Language.Haskell.Exts.Simple as Hs
+import System.Directory
+import System.Exit
+import System.Process
 import System.Timeout.Lifted
 import Telegram.Bot.Simple
 
@@ -39,6 +46,13 @@ lambdabotVersion = VERSION_lambdabot_core
 
 telegramPlugins :: [String]
 telegramPlugins = ["telegram"]
+
+-- eval excluded because we provide it by ourselves
+customHaskellPlugins :: [String]
+customHaskellPlugins =
+  [ "check", "djinn", "free", "haddock", "hoogle", "instances"
+  , "pl", "pointful", "pretty", "source", "type", "undo", "unmtl"
+  ]
 
 telegramPlugin :: Module TelegramState
 telegramPlugin = newModule
@@ -83,6 +97,25 @@ telegramPlugin = newModule
                 <> lambdabotVersion
                 <> ". git clone https://github.com/lambdabot/lambdabot.git"
               ]
+        }
+    , (command "run")
+        { help = say "run <expr>. You have Haskell, 3 seconds and no IO. Go nuts!"
+        , process = lim80 . runGHC
+        }
+    , (command "let")
+        { aliases = ["define"] -- because @define always gets "corrected" to @undefine
+        , help = say "let <x> = <e>. Add a binding"
+        , process = lim80 . define
+        }
+    , (command "undefine")
+        { help = say "undefine. Reset evaluator local bindings"
+        , process = \s -> 
+            let chatInfo = readChatInfoFromSource s
+                s' = dropChatInfoFromSource chatInfo s
+             in 
+            if null s'
+              then resetCustomL_hs chatInfo >> say "Undefined."
+              else say "There's currently no way to undefine just one thing.  Say @undefine (with no extra words) to undefine everything."
         }
     ]
   }
@@ -146,7 +179,232 @@ telegramLoop fp = do
   ldebug $ "[DEBUG] : lambdabot : input read : " <> show msg
   let s' = Text.dropWhile isSpace (msgMessage msg)
   when (not (Text.null s')) $ do
-    io $ appendFile fp $ Text.unpack $ msgMessage msg
+    io $ appendFile fp $ Text.unpack (msgMessage msg) <> "\n"
     feed (msgChatId msg) s'
   continue <- lift $ gets (Map.member "telegramrc" . ircPersists)
   when continue $ telegramLoop fp
+
+-- ** Eval
+
+args :: String -> String -> [String] -> [String] -> [String]
+args load src exts trusted = concat
+    [ ["-S"]
+    , map ("-s" ++) trusted
+    , map ("-X" ++) exts
+    , ["--no-imports", "-l", load]
+    , ["--expression=" ++ decodeString src]
+    , ["+RTS", "-N", "-RTS"]
+    ]
+
+isEval :: MonadLB m => String -> m Bool
+isEval str = do
+    prefixes <- getConfig evalPrefixes
+    return (prefixes `arePrefixesWithSpaceOf` str)
+
+dropPrefix :: String -> String
+dropPrefix = dropWhile (' ' ==) . drop 2
+
+
+runGHC :: MonadLB m => String -> m String
+runGHC src' = do
+    let chatInfo = readChatInfoFromSource src'
+        src = dropChatInfoFromSource chatInfo src'
+
+    load    <- findCustomL_hs chatInfo
+    binary  <- getConfig muevalBinary
+    exts    <- getConfig languageExts
+    trusted <- getConfig trustedPackages
+    (_,out,err) <- io (readProcessWithExitCode binary (args load src exts trusted) "")
+    case (out,err) of
+        ([],[]) -> return "Terminated\n"
+        _       -> do
+            let o = mungeEnc out
+                e = mungeEnc err
+            return $ case () of {_
+                | null o && null e -> "Terminated\n"
+                | null o           -> e
+                | otherwise        -> o
+            }
+
+------------------------------------------------------------------------
+-- define a new binding
+
+define :: MonadLB m => String -> m String
+define [] = return "Define what?"
+define src' = do
+    exts <- getConfig languageExts
+    let chatInfo = readChatInfoFromSource src'
+        src = dropChatInfoFromSource chatInfo src'
+        mode = Hs.defaultParseMode{ Hs.extensions = map Hs.classifyExtension exts }
+    case Hs.parseModuleWithMode mode (decodeString src) of
+        Hs.ParseOk srcModule -> do
+            l <- findCustomL_hs chatInfo
+            res <- io (Hs.parseFile l)
+            case res of
+                Hs.ParseFailed loc err -> return (Hs.prettyPrint loc ++ ':' : err)
+                Hs.ParseOk lModule -> do
+                    let merged = mergeModules lModule srcModule
+                    case moduleProblems merged of
+                        Just msg -> return msg
+                        Nothing  -> customComp chatInfo merged
+        Hs.ParseFailed _loc err -> return ("Parse failed: " ++ err)
+
+-- merge the second module _into_ the first - meaning where merging doesn't
+-- make sense, the field from the first will be used
+mergeModules :: Hs.Module -> Hs.Module -> Hs.Module
+mergeModules (Hs.Module  head1  exports1 imports1 decls1)
+             (Hs.Module _head2 _exports2 imports2 decls2)
+    = Hs.Module head1 exports1
+        (mergeImports imports1 imports2)
+        (mergeDecls   decls1   decls2)
+    where
+        mergeImports x y = nub' (sortBy (comparing Hs.importModule) (x ++ y))
+        mergeDecls x y = sortBy (comparing funcNamesBound) (x ++ y)
+
+        -- this is a very conservative measure... we really only even care about function names,
+        -- because we just want to sort those together so clauses can be added in the right places
+        -- TODO: find out whether the [Hs.Match] can contain clauses for more than one function (e,g. might it be a whole binding group?)
+        funcNamesBound (Hs.FunBind ms) = nub $ sort [ n | Hs.Match n _ _ _ <- ms]
+        funcNamesBound _ = []
+-- we simply do not care about XML cases
+mergeModules _ _ = error "Not supported module met"
+
+moduleProblems :: Hs.Module -> Maybe [Char]
+moduleProblems (Hs.Module _head pragmas _imports _decls)
+    | safe `notElem` langs  = Just "Module has no \"Safe\" language pragma"
+    | trusted `elem` langs  = Just "\"Trustworthy\" language pragma is set"
+    | otherwise             = Nothing
+    where
+        safe    = Hs.name "Safe"
+        trusted = Hs.name "Trustworthy"
+        langs = concat [ ls | Hs.LanguagePragma ls <- pragmas ]
+-- we simply do not care about XML cases
+moduleProblems _ = error "Not supported module met"
+
+moveFile :: FilePath -> FilePath -> IO ()
+moveFile from to = do
+  copyFile from to
+  removeFile from
+
+customComp :: MonadLB m => ChatInfo -> Hs.Module -> m String
+customComp chatInfo src = do
+    -- calculate temporary filename for source, interface and compiled library
+    let hs = getDotFilename chatInfo "hs"
+        hi = getDotFilename chatInfo "hi"
+        lib = getDotFilename chatInfo "o"
+        lhs = getLFilename chatInfo
+    -- Note we copy to .L.hs, not L.hs. This hides the temporary files as dot-files
+    io (writeFile hs (Hs.prettyPrint src))
+
+    -- and compile .L.hs
+    -- careful with timeouts here. need a wrapper.
+    trusted <- getConfig trustedPackages
+    let ghcArgs = concat
+            [ ["-O", "-v0", "-c", "-Werror", "-fpackage-trust"]
+            , concat [["-trust", pkg] | pkg <- trusted]
+            , [hs]
+            ]
+    ghc <- getConfig ghcBinary
+    (c, o',e') <- io (readProcessWithExitCode ghc ghcArgs "")
+    -- cleanup, 'try' because in case of error the files are not generated
+    _ <- io (try (removeFile hi) :: IO (Either SomeException ()))
+    _ <- io (try (removeFile lib)  :: IO (Either SomeException ()))
+
+    case (mungeEnc o', mungeEnc e') of
+        ([],[]) | c /= ExitSuccess -> do
+                    io (removeFile hs)
+                    return "Error."
+                | otherwise -> do
+                    l <- lb (findLBFileForWriting lhs)
+                    io (moveFile hs l)
+                    return "Defined."
+        (ee,[]) -> return ee
+        (_ ,ee) -> return ee
+
+munge, mungeEnc :: String -> String
+munge = expandTab 8 . strip (=='\n')
+mungeEnc = encodeString . munge
+
+resetCustomL_hs :: MonadLB m => ChatInfo -> m ()
+resetCustomL_hs chatInfo = do
+    let lhs = getLFilename chatInfo
+    p <- findPristine_hs
+    contents <- liftIO (readFile p)
+    l <- lb (findLBFileForWriting lhs)
+    io (writeFile l $ editModuleName chatInfo contents)
+
+-- find Pristine.hs; if not found, we try to install a compiler-specific
+-- version from lambdabot's data directory, and finally the default one.
+findPristine_hs :: MonadLB m => m FilePath
+findPristine_hs = do
+    p <- lb (findLBFileForReading "Pristine.hs")
+    case p of
+        Nothing -> do
+            p' <- lb (findOrCreateLBFile "Pristine.hs")
+            p0 <- lb (findLBFileForReading ("Pristine.hs." ++ show (__GLASGOW_HASKELL__ :: Integer)))
+            p0' <- case p0 of
+                Nothing -> lb (findLBFileForReading "Pristine.hs.default")
+                p0' -> return p0'
+            case p0' of
+                Just p0'' -> do
+                    p'' <- lb (findLBFileForWriting "Pristine.hs")
+                    io (copyFile p0'' p'')
+                _ -> return ()
+            return p'
+        Just p' -> return p'
+
+-- find L.hs; if not found, we copy it from Pristine.hs
+findCustomL_hs :: MonadLB m => ChatInfo -> m FilePath
+findCustomL_hs chatInfo = do
+    let lhs = getLFilename chatInfo
+    file <- lb (findLBFileForReading lhs)
+    case file of
+        -- if L.hs
+        Nothing -> resetCustomL_hs chatInfo >> lb (findOrCreateLBFile lhs)
+        Just file' -> return file'
+
+nub' :: Ord a => [a] -> [a]
+nub' = Set.toList . Set.fromList
+
+
+data ChatInfo = ChatInfo
+  { chatInfoChatId :: !Text
+  , chatInfoType   :: !ChatType
+  }
+
+data ChatType = Public | Private
+
+renderChatType :: ChatType -> String
+renderChatType Public = ""
+renderChatType Private = "P"
+
+readChatInfoFromSource :: String -> ChatInfo
+readChatInfoFromSource str =
+  let prefix = takeWhile (\ch -> isDigit ch || (ch == '-')) str
+      mode = case find (== '-') str of
+        Nothing -> Public
+        Just _  -> Private
+      onlyChatId = filter isDigit prefix
+  in ChatInfo (Text.pack onlyChatId) mode
+
+dropChatInfoFromSource :: ChatInfo -> String -> String
+dropChatInfoFromSource ChatInfo{..} str = dropWhile isSpace $ drop prefixLength str
+  where
+    prefixLength = Text.length chatInfoChatId + m
+    m = case chatInfoType of
+      Private -> 1
+      Public  -> 0
+
+getDotFilename :: ChatInfo -> String -> FilePath
+getDotFilename ChatInfo{..} extension
+  = ".L" <> renderChatType chatInfoType <> Text.unpack chatInfoChatId <> "." <> extension
+
+getLFilename :: ChatInfo -> FilePath
+getLFilename ChatInfo{..}
+  = "L" <> renderChatType chatInfoType <> Text.unpack chatInfoChatId <> ".hs"
+
+editModuleName :: ChatInfo -> String -> String
+editModuleName ChatInfo{..} str =
+  let moduleName = "L" <> Text.pack (renderChatType chatInfoType) <> chatInfoChatId
+      moduleLine = "module " <> moduleName <> " where"
+  in (Text.unpack . Text.replace "module L where" moduleLine . Text.pack) str


### PR DESCRIPTION
Following situation now becomes impossible:
- In chat 1: `/let x = 2 :: Int`
- In chat 2: `/run x`
ER (in chat 2): `Error: Variable not in scope: x`
AR: `2`.

Shared state across chats removed with this PR.