### PR TITLE
Unescape unicode output from interpreter

### DIFF
--- a/State/Pristine.hs
+++ b/State/Pristine.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE Safe #-}
-{-# OPTIONS_GHC -interactive-print=Text.Pretty.Simple.pPrint #-}
 {-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFoldable #-}

--- a/lambdabot-telegram-plugins.cabal
+++ b/lambdabot-telegram-plugins.cabal
@@ -45,6 +45,7 @@ library
                     , lifted-base
                     , monad-control
                     , mtl
+                    , pretty-simple
                     , process
                     , regex-tdfa
                     , split

--- a/src/Lambdabot/Plugin/Telegram.hs
+++ b/src/Lambdabot/Plugin/Telegram.hs
@@ -17,6 +17,7 @@ import Data.Ord
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TL
 import Data.Version
 import qualified Language.Haskell.Exts.Simple as Hs
 import System.Directory
@@ -24,6 +25,7 @@ import System.Exit
 import System.Process
 import System.Timeout.Lifted
 import Telegram.Bot.Simple
+import Text.Pretty.Simple (pStringNoColor)
 
 import Lambdabot.Command
 import Lambdabot.Config.Telegram
@@ -153,7 +155,7 @@ handleMsg msg = do
   let out = Msg
         { msgChatId = getTgChatId msg
         , msgMsgId = getTgMsgId msg
-        , msgMessage = (Text.pack . decodeString) str
+        , msgMessage = (TL.toStrict . pStringNoColor . decodeString) str
         }
   ldebug $ "handleMsg : irc : " <> (show msg)
   ldebug $ "handleMsg : out : " <> (show out)


### PR DESCRIPTION
Thanks to @Bodigrim for suggestion to use support `pretty-simple`: https://github.com/haskell/core-libraries-committee/issues/26#issuecomment-1011030635

With following PR, bot returns the output in unicode without escaping it:

```
/run "λ"
"λ"
```