### PR TITLE
Enable `-XMagicHash` extension

### DIFF
--- a/src/Lambdabot/Config/Telegram.hs
+++ b/src/Lambdabot/Config/Telegram.hs
@@ -27,6 +27,7 @@ defaultExts =
     [ "ImplicitPrelude" -- workaround for bug in hint package
     , "ExtendedDefaultRules"
     , "TypeApplications"
+    , "MagicHash"
     ]
 
 -- | Language extensions used by Telegram Lambdabot: combination of predefined 'defaultExts' and user-defined ones.


### PR DESCRIPTION
Enable `MagicHash` extension by default. `MutVar#` considered as error.