### PR TITLE
Bump `telegram-bot-simple` version and fix receiving messages

### DIFF
--- a/lambdabot-telegram-plugins.cabal
+++ b/lambdabot-telegram-plugins.cabal
@@ -52,7 +52,7 @@ library
                     , directory
                     , edit-distance
                     , haskell-src-exts-simple
-                    , telegram-bot-simple >= 0.5.2
+                    , telegram-bot-simple >= 0.6
                     , text
                     , lambdabot-core
                     , lifted-base


### PR DESCRIPTION
With Telegram Bot API 6.2 there is a new `MessageEntity` called `custom_emoji`. It breaks the bot in runtime.

```
DecodeFailure "Error in $.result[0].message.entities[0].type: When parsing Telegram.Bot.API.Types.MessageEntityType expected a String with the tag of a constructor but got custom_emoji."
```

It was fixed in `telegram-bot-simple-0.6`. This PR is intended to bump the dependency version and fix bot runtime.