### PR TITLE
Fix telegram bot

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,6 @@
 packages: .
 
 write-ghc-environment-files: never
+
+allow-newer: HTTP:network
+allow-newer: HTTP:base

--- a/lambdabot-telegram-plugins.cabal
+++ b/lambdabot-telegram-plugins.cabal
@@ -45,14 +45,14 @@ library
     hs-source-dirs:   src
     ghc-options:      -Wall
     default-language: Haskell2010
-    build-depends:    base < 4.17
+    build-depends:    base
                     , containers
                     , dependent-map
                     , dependent-sum
                     , directory
                     , edit-distance
                     , haskell-src-exts-simple
-                    , telegram-bot-simple >= 0.6
+                    , telegram-bot-simple >= 0.14.1
                     , telegram-bot-api
                     , text
                     , lambdabot-core
@@ -78,7 +78,7 @@ executable telegram-lambdabot
     other-modules:    Modules
                     , Paths_lambdabot_telegram_plugins
 
-    build-depends:    base < 4.17
+    build-depends:    base
                     , lambdabot-core
                     , lambdabot-haskell-plugins
                     , lambdabot-telegram-plugins

--- a/src/Lambdabot/Plugin/Telegram/Bot.hs
+++ b/src/Lambdabot/Plugin/Telegram/Bot.hs
@@ -286,13 +286,14 @@ handleAction (SendBack msg) model = model <# do
             , sendMessageText                  = "```\n" <> response <> "\n```\n"
             , sendMessageParseMode             = Just MarkdownV2
             , sendMessageEntities              = Nothing
-            , sendMessageDisableWebPagePreview = Nothing
             , sendMessageDisableNotification   = Nothing
             , sendMessageProtectContent        = Nothing
             , sendMessageReplyToMessageId      = mreplyMessageId
-            , sendMessageAllowSendingWithoutReply = Nothing
             , sendMessageReplyMarkup           = Nothing
             , sendMessageMessageThreadId       = Nothing
+            , sendMessageBusinessConnectionId  = Nothing
+            , sendMessageLinkPreviewOptions    = Nothing
+            , sendMessageReplyParameters       = Nothing
             }
       _ <- liftClientM (sendMessage req)
       pure ()


### PR DESCRIPTION
Bump telegram bot version to the most recent now. As consequence, bot is built with GHC 9.4.8.