### PR TITLE
Switch to `mueval-core` and add time limit

### DIFF
--- a/src/Lambdabot/Config/Telegram.hs
+++ b/src/Lambdabot/Config/Telegram.hs
@@ -14,7 +14,7 @@ config "telegramBotName"           [t| String                  |] [| "TelegramLa
 config "telegramLambdabotVersion"  [t| Version                 |] [| Version [] [] |]
 
 -- | Path to @mueval@ executable.
-config "muevalBinary"       [t| String                  |] [| "mueval"      |]
+config "muevalBinary"       [t| String                  |] [| "mueval-core"      |]
 
 
 -- | Extensions to enable for the interpreted expression

--- a/src/Lambdabot/Plugin/Telegram.hs
+++ b/src/Lambdabot/Plugin/Telegram.hs
@@ -243,6 +243,7 @@ args load src exts trusted = concat
     , map ("-X" ++) exts
     , ["--no-imports", "-l", load]
     , ["--expression=" ++ decodeString src]
+    , ["--time-limit=" ++ "120"]
     , ["+RTS", "-N", "-RTS"]
     ]
 


### PR DESCRIPTION
It turns out that something is broken with mueval, it started to constantly returning `mueval: ExitFailure 1` . No luck to invoke binary on its own. Symptoms are similar to https://github.com/TerenceNg03/mueval/issues/19, but it has nothing to do with Lens, even simple '0' fails to evaluate. 

But switching to `mueval-core` + adding timeout seems to improve response from `mueval` package.