### PR TITLE
Switching back to upstream `mueval`

### DIFF
--- a/src/Lambdabot/Config/Telegram.hs
+++ b/src/Lambdabot/Config/Telegram.hs
@@ -14,7 +14,7 @@ config "telegramBotName"           [t| String                  |] [| "TelegramLa
 config "telegramLambdabotVersion"  [t| Version                 |] [| Version [] [] |]
 
 -- | Path to @mueval@ executable.
-config "muevalBinary"       [t| String                  |] [| "mueval-core"      |]
+config "muevalBinary"       [t| String                  |] [| "mueval"      |]
 
 
 -- | Extensions to enable for the interpreted expression


### PR DESCRIPTION
Of course, `mueval-0.9.4` was released in the meantime, there is no `mueval-core` anymore.